### PR TITLE
Add changelogs to fastlane

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/10.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10.txt
@@ -1,0 +1,1 @@
+This release adds support for bLIP-11: NameDesc!

--- a/fastlane/metadata/android/en-US/changelogs/5.txt
+++ b/fastlane/metadata/android/en-US/changelogs/5.txt
@@ -1,0 +1,1 @@
+In which OBW is announced during TabConf and whatever we had here in whatever state is launched to the public.

--- a/fastlane/metadata/android/en-US/changelogs/6.txt
+++ b/fastlane/metadata/android/en-US/changelogs/6.txt
@@ -1,0 +1,5 @@
+This fixes some issues related to syncing of onchain transaction history that could cause a broken state that would then break all further onchain transactions and channel openings since the wallet would try to spend outputs that were already spent.
+
+It improves handling of connections to Electrum servers such that the wallet is more resilient, specially over Tor.
+
+It updates the bundled channel graph file to make the initial channels sync process much faster.

--- a/fastlane/metadata/android/en-US/changelogs/7.txt
+++ b/fastlane/metadata/android/en-US/changelogs/7.txt
@@ -1,0 +1,5 @@
+This fixes a bug with URL parsing that broke under some circumstances, notably the LUD-08 "fast-withdraw" variation of lnurl-withdraw.
+
+It does so by getting rid of the last piece of Java code inside Immortan's codebase, the URI parser.
+
+It also adds a "fast" mode to the LUD-07 parser, which means it's much easier to conjure custom hosted channel QR codes with custom secrets without running a server.

--- a/fastlane/metadata/android/en-US/changelogs/9.txt
+++ b/fastlane/metadata/android/en-US/changelogs/9.txt
@@ -1,0 +1,9 @@
+Previously v0.1.7 was called "the Signet" because it came with Signet support (on a different APK), but it was succeeded by this one because it had a horrible bug that caused the app to crash if a hosted channel ever got an error.
+
+It also fixed a bug with Electrum random server rotation that was actually a memory leak and could also double as a resource drain if the servers were faulty (it would just keep adding more and more servers to the pool without ever removing them).
+
+v0.1.8 fixes the HC error issue and also introduces
+
+* human-readable errors for HCs,
+* fixes an issue with feerate + amount calculation for onchain txs that sometimes caused the transactions to not be updated and the "proceed" button to be unclickable,
+* removes a weird Java-like class that was causing the issues above for being too complicated and replaces it with a simple function -- maybe this will break something, but it seems to be working much better now, and the code is simpler and more understandable, not that the wallet user should care about that part.


### PR DESCRIPTION
Reguested in F-Droid MR here: https://gitlab.com/fdroid/fdroiddata/-/merge_requests/12216#note_1201349964

Also it would be perfect if future github release notes appeared in the changelog files before the release is tagged. So the tag already contains the changelogs/XXX.txt file where XXX is the versionCode of the release to be released.