### PR TITLE
Prevent mnemonic words from being copied to clipboard on tap.

### DIFF
--- a/app/src/main/scala/BaseActivity.scala
+++ b/app/src/main/scala/BaseActivity.scala
@@ -220,7 +220,7 @@ trait BaseActivity extends AppCompatActivity { self =>
       mnemonicWord ~ mnemonicIndex <- LNParams.secret.mnemonic.zipWithIndex
     ) {
       val item = s"${mnemonicIndex + 1} $mnemonicWord"
-      addFlowChip(content.flow, item, R.drawable.border_green)
+      addFlowChip(content.flow, item, R.drawable.border_green, _ => {})
     }
   }
 


### PR DESCRIPTION
Currently, if a chip does not explicitly set an onTap callback, or have shareText explicitly set, the chip will copy its contents to the clipboard on tap. Because it is possible that a user accidentally taps the chips presenting the mnemonic words, this behavior should be inhibited as the text contains both the mnemonic word and its position in the recovery phrase.